### PR TITLE
Remove pem_file_path

### DIFF
--- a/PredictingNFLGames/run_certbot_update.py
+++ b/PredictingNFLGames/run_certbot_update.py
@@ -1,27 +1,22 @@
 import paramiko
 import os
 
-
-def run_remote_command(hostname, username, pem_file_path, command):
+def run_remote_command(hostname, username, key, command):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
+    
     try:
-        # Load the private key from the .pem file
-        key = paramiko.RSAKey.from_private_key_file(pem_file_path)
-
-        ssh.connect(hostname, username=username, pkey=key)
+        ssh.connect(hostname, username=username, key_filename=key)
         stdin, stdout, stderr = ssh.exec_command(command)
         print(stdout.read().decode())
         print(stderr.read().decode())
     finally:
         ssh.close()
 
-
 if __name__ == "__main__":
     hostname = os.getenv("EC2_PUBLIC_IP")
     username = os.getenv("EC2_USERNAME")
-    pem_file_path = os.getenv("EC2_SSH_KEY")
+    key = os.getenv("EC2_SSH_KEY")
     command = "sudo certbot renew --nginx --cert-name promatchpredict.com"
-
-    run_remote_command(hostname, username, pem_file_path, command)
+    
+    run_remote_command(hostname, username, key, command)


### PR DESCRIPTION
Earlier version required the pem file to be in github, but I don't want that exposed to the public, so I'm having this read the ssh key as a secret instead